### PR TITLE
Implement SDL2 screenshot support using SDL2_image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This repository contains the source code of the TomeNET SDL2 client for Linux. T
 
 **Building**
 
-1. Ensure SDL2, SDL2_mixer, SDL2_ttf and SDL2_net development headers are installed.
+1. Ensure SDL2, SDL2_mixer, SDL2_ttf, SDL2_net and SDL2_image development headers are installed.
 2. From the repository root, run:
 
 ```bash

--- a/src/makefile.sdl2
+++ b/src/makefile.sdl2
@@ -10,7 +10,7 @@
 #
 # Flags:
 #
-#  - USE_SDL2 - Required for all SDL2 clients, uses SDL2 and SDL2_ttf libraries. Is set as default.
+#  - USE_SDL2 - Required for all SDL2 clients, uses SDL2, SDL2_ttf and SDL2_image libraries. Is set as default.
 #
 #  - SOUND_SDL - Optional, using SDL2_mixer library and provides SDL sound/music support. Is set as default.
 #
@@ -195,7 +195,7 @@ date:
 # Rules for building the TomeNET SDL2 (test) client
 #
 tomenet tomenet.test: CFLAGS = -Djezek_t $(COMMON_FLAGS_LINUX) -DUSE_SDL2 -DSOUND_SDL $(shell $(SDL_CONFIG_LINUX) --cflags)
-tomenet tomenet.test: LIBS = -lm -lSDL2_mixer -lSDL2_ttf -lSDL2_net $(shell $(SDL_CONFIG_LINUX) --libs)
+tomenet tomenet.test: LIBS = -lm -lSDL2_mixer -lSDL2_ttf -lSDL2_net -lSDL2_image $(shell $(SDL_CONFIG_LINUX) --libs)
 # Compiler for lient gets additional security hardening flags (linker too)
 tomenet: CFLAGS += -fstack-protector -D_FORTIFY_SOURCE=2 -g -O2
 tomenet: $(CLI_OBJS_LINUX) $(CLI_LUAOBJS_LINUX) $(TOLUAOBJS_LINUX)
@@ -208,7 +208,7 @@ tomenet.test: $(CLI_OBJS_LINUX) $(CLI_LUAOBJS_LINUX) $(TOLUAOBJS_LINUX)
 	$(CC_LINUX) $(CFLAGS) -o tomenet $(CLI_OBJS_LINUX) $(CLI_LUAOBJS_LINUX) $(TOLUAOBJS_LINUX) $(LIBS)
 
 tomenet.exe tomenet.test.exe: CFLAGS = -Djezek_t $(COMMON_FLAGS_MINGW) -DUSE_SDL2 -DSOUND_SDL $(shell $(SDL_CONFIG_MINGW) --cflags)
-tomenet.exe tomenet.test.exe: LIBS = -lregex -lSDL2_mixer -lSDL2_ttf -lSDL2_net $(shell $(SDL_CONFIG_MINGW) --libs)
+tomenet.exe tomenet.test.exe: LIBS = -lregex -lSDL2_mixer -lSDL2_ttf -lSDL2_net -lSDL2_image $(shell $(SDL_CONFIG_MINGW) --libs)
 # Compiler for lient gets additional security hardening flags (linker too)
 tomenet.exe: CFLAGS += -D_FORTIFY_SOURCE=2 -O2
 tomenet.exe: $(CLI_OBJS_MINGW) $(CLI_LUAOBJS_MINGW) $(TOLUAOBJS_MINGW)


### PR DESCRIPTION
## Summary
- link SDL2_image for PNG screenshot capability
- update dependencies docs
- implement screenshot with SDL2_image in `sdl2_win_term_main_screenshot`
- initialize SDL2_image when starting SDL2 client
- remove previously added stb_image_write

## Testing
- `make -f makefile.sdl2 tomenet`

------
https://chatgpt.com/codex/tasks/task_e_68636d29d8d08332a17ee1102d4ebe86