### PR TITLE
Add compile-time SDL2 sticky keys option

### DIFF
--- a/src/makefile.sdl2
+++ b/src/makefile.sdl2
@@ -215,7 +215,7 @@ date:
 #
 # Rules for building the TomeNET SDL2 (test) client
 #
-tomenet tomenet.test: CFLAGS = -Djezek_t $(COMMON_FLAGS_LINUX) -DUSE_SDL2 -DSOUND_SDL $(shell $(SDL_CONFIG_LINUX) --cflags)
+tomenet tomenet.test: CFLAGS = -Djezek_t $(COMMON_FLAGS_LINUX) -DUSE_SDL2 -DSOUND_SDL -DSDL2_STICKY_KEYS $(shell $(SDL_CONFIG_LINUX) --cflags)
 tomenet tomenet.test: LIBS = -lm -lSDL2_mixer -lSDL2_ttf -lSDL2_net -lSDL2_image $(shell $(SDL_CONFIG_LINUX) --libs)
 # Compiler for lient gets additional security hardening flags (linker too)
 tomenet: CFLAGS += -fstack-protector -D_FORTIFY_SOURCE=2 -g -O2
@@ -228,7 +228,7 @@ tomenet.test: CPPFLAGS += -DTEST_CLIENT
 tomenet.test: $(CLI_OBJS_LINUX) $(CLI_LUAOBJS_LINUX) $(TOLUAOBJS_LINUX)
 	$(CC_LINUX) $(CFLAGS) -o tomenet $(CLI_OBJS_LINUX) $(CLI_LUAOBJS_LINUX) $(TOLUAOBJS_LINUX) $(LIBS)
 
-tomenet.exe tomenet.test.exe: CFLAGS = -Djezek_t $(COMMON_FLAGS_MINGW) -DUSE_SDL2 -DSOUND_SDL $(shell $(SDL_CONFIG_MINGW) --cflags)
+tomenet.exe tomenet.test.exe: CFLAGS = -Djezek_t $(COMMON_FLAGS_MINGW) -DUSE_SDL2 -DSOUND_SDL -DSDL2_STICKY_KEYS $(shell $(SDL_CONFIG_MINGW) --cflags)
 tomenet.exe tomenet.test.exe: LIBS = -lregex -lSDL2_mixer -lSDL2_ttf -lSDL2_net -lSDL2_image $(shell $(SDL_CONFIG_MINGW) --libs)
 # Compiler for lient gets additional security hardening flags (linker too)
 tomenet.exe: CFLAGS += -D_FORTIFY_SOURCE=2 -O2


### PR DESCRIPTION
## Summary
- wrap sticky key handling in `SDL2_STICKY_KEYS` macro in `main-sdl2.c`
- enable `SDL2_STICKY_KEYS` by default in `makefile.sdl2`

## Testing
- `cd src && make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_686d9e9d6f20833298f07a6591b14f36