### PR TITLE
Add window decorations toggle in SDL2 client

### DIFF
--- a/src/client/c-util.c
+++ b/src/client/c-util.c
@@ -11371,9 +11371,12 @@ static void do_cmd_options_fonts(void) {
 		else
 			Term_putstr(0, 2, -1, TERM_WHITE, format("  \377yENTER\377w enter a specific font name, \377yL\377w %s logfont, \377yESC\377w keep changes and exit", use_logfont_ini ? "disable" : "enable"));
 #else
-		Term_putstr(0, 2, -1, TERM_WHITE, "  \377yENTER\377w enter a specific font name, \377yESC\377w keep changes and exit");
+                Term_putstr(0, 2, -1, TERM_WHITE, "  \377yENTER\377w enter a specific font name, \377yESC\377w keep changes and exit");
 #endif
-		Term_putstr(0, 4, -1, TERM_WHITE, format("  %d font%s and %d graphic font%s available, \377yl\377w to list in message window", fonts, fonts == 1 ? "" : "s", graphic_fonts, graphic_fonts == 1 ? "" : "s"));
+#ifdef USE_SDL2
+                Term_putstr(0, 3, -1, TERM_WHITE, format("  d toggle window decorations (%s)", window_decorations ? "on" : "off"));
+#endif
+                Term_putstr(0, 4, -1, TERM_WHITE, format("  %d font%s and %d graphic font%s available, \377yl\377w to list in message window", fonts, fonts == 1 ? "" : "s", graphic_fonts, graphic_fonts == 1 ? "" : "s"));
 
 		/* Display the windows */
 		for (j = 0; j < ANGBAND_TERM_MAX; j++) {
@@ -11426,13 +11429,23 @@ static void do_cmd_options_fonts(void) {
 			inkey_msg = TRUE; /* And suppress macros again.. */
 			break;
 
-		case 'v':
-			if (y == 0) {
-				c_msg_print("\377yThe main window must always be visible.");
-				break; /* main window cannot be invisible */
-			}
-			term_toggle_visibility(y);
-			break;
+                case 'v':
+                        if (y == 0) {
+                                c_msg_print("\377yThe main window must always be visible.");
+                                break; /* main window cannot be invisible */
+                        }
+                        term_toggle_visibility(y);
+                        break;
+
+                case 'd':
+#ifdef USE_SDL2
+                        window_decorations = !window_decorations;
+                        apply_window_decorations();
+                        Term_putstr(0, 3, -1, TERM_WHITE, format("  d toggle window decorations (%s)", window_decorations ? "on" : "off"));
+#else
+                        bell();
+#endif
+                        break;
 
 		case ' ':
 			if (y == 0) {

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -280,8 +280,18 @@ static bool read_mangrc(cptr filename) {
 		if (!strncmp(buf, "fullauto", 8))
 			skip = TRUE;
 
-		/* READABILITY_BLUE */
-		if (!strncmp(buf, "lighterDarkBlue", 15)) lighterdarkblue = TRUE;
+                /* READABILITY_BLUE */
+                if (!strncmp(buf, "lighterDarkBlue", 15)) lighterdarkblue = TRUE;
+
+#ifdef USE_SDL2
+                if (!strncmp(buf, "window_decorations", 18)) {
+                        char *p;
+
+                        p = strtok(buf, " \t\n");
+                        p = strtok(NULL, "\t\n");
+                        if (p) window_decorations = (atoi(p) != 0);
+                }
+#endif
 
 		/* Color map */
 		if (!strncmp(buf, "colormap_", 9)) {
@@ -863,8 +873,11 @@ bool write_mangrc(bool creds_only, bool update_creds, bool audiopacks_only) {
 
 			fputs("# Use lighter 'dark blue' colour to increase readability on some screens\n", config2);
 			fputs("# Sets blue to #0033ff instead of #0000ff\n", config2);
-			fputs("lighterDarkBlue\n", config2);
-			fputs("\n", config2);
+                        fputs("lighterDarkBlue\n", config2);
+#ifdef USE_SDL2
+                        fputs(format("window_decorations\t\t%d\n", window_decorations ? 1 : 0), config2);
+#endif
+                        fputs("\n", config2);
 
 			fputs("# Full color remapping\n", config2);
 			fputs("# 0 = black, 1 = white, 2 = gray, 3 = orange, 4 = red, 5 = green, 6 = blue\n", config2);

--- a/src/client/externs.h
+++ b/src/client/externs.h
@@ -58,6 +58,7 @@ extern void get_palette(byte c, byte *r, byte *g, byte *b);
 extern void refresh_palette(void);
 extern int get_misc_fonts(char *output_list, int max_misc_fonts, int max_font_name_length, int max_fonts);
 extern void set_window_title_sdl2(int term_idx, cptr title);
+extern void apply_window_decorations(void);
 
 extern char *SDL2_USER_PATH, *SDL2_GAME_PATH;
 extern char SDL2_PATH_SEP[2];
@@ -380,6 +381,7 @@ extern cptr ANGBAND_DIR_SCPT;
 extern cptr ANGBAND_DIR_GAME;
 
 extern bool disable_numlock;
+extern bool window_decorations;
 #ifdef WINDOWS
 extern bool use_logfont, use_logfont_ini;
 #endif

--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -219,9 +219,10 @@ static errr Infowin_init(int x, int y, int w, int h, unsigned int b, Pixel b_col
 
 	/*** Create the SDL_Window* 'window' from data ***/
 
-	/* Create the Window. */
-	//TODO jezek - Add "window_decorations" into config and allow to toggle in game menu.
-	SDL_Window *window = SDL_CreateWindow("", x, y, w, h, SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_BORDERLESS);
+        /* Create the Window. */
+        Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
+        if (!window_decorations) flags |= SDL_WINDOW_BORDERLESS;
+        SDL_Window *window = SDL_CreateWindow("", x, y, w, h, flags);
 
 	if (window == NULL) {
 		fprintf(stderr, "Error creating window in Infowin_init\n");
@@ -3054,10 +3055,19 @@ void term_toggle_visibility(int term_idx) {
 
 /* Returns true if terminal window specified by term_idx is currently visible. */
 bool term_get_visibility(int term_idx) {
-	if (term_idx < 0 || term_idx >= ANGBAND_TERM_MAX) return(false);
+        if (term_idx < 0 || term_idx >= ANGBAND_TERM_MAX) return(false);
 
-	/* Only windows initialized in ang_term array are currently visible. */
-	return((bool)ang_term[term_idx]);
+        /* Only windows initialized in ang_term array are currently visible. */
+        return((bool)ang_term[term_idx]);
+}
+
+void apply_window_decorations(void) {
+        SDL_bool bordered = window_decorations ? SDL_TRUE : SDL_FALSE;
+        for (int i = 0; i < ANGBAND_TERM_MAX; i++) {
+                if (!term_get_visibility(i)) continue;
+                term_data *td = term_idx_to_term_data(i);
+                SDL_SetWindowBordered(td->win->window, bordered);
+        }
 }
 
 void get_term_main_font_name(char *buf) {

--- a/src/client/variable.c
+++ b/src/client/variable.c
@@ -215,6 +215,7 @@ cptr ANGBAND_DIR_XTRA;
 cptr ANGBAND_DIR_GAME;
 
 bool disable_numlock = FALSE;
+bool window_decorations = FALSE;
 bool bad_solid_mapping = FALSE;
 #ifdef WINDOWS
 bool use_logfont = FALSE, use_logfont_ini;

--- a/tomenet.cfg
+++ b/tomenet.cfg
@@ -1,1 +1,228 @@
-.tomenetrc
+## TomeNET configuration file for clients running on *NIX platforms:
+##
+##                   *** !!!     NOTE:     !!! ***
+##   TomeNET will read .tomenetrc IN YOUR HOME FOLDER, not in the
+##   TomeNET folder (can be changed via -f<cfgfile> cmdline option)!
+##
+## You should copy this file to your home directory. The client will read the
+## settings in this file and update some of them after you quit.
+## If you start TomeNET without a .tomenetrc file in your home folder, it will
+## automatically create a basic one there.
+##
+## Lines that start with '#' will ignored. Please make sure that each line
+## includes the expected number of parameters or your client may crash.
+
+## Automatic login settings
+
+## - Account name - can be left empty
+#nick		Gandalf
+
+## - Account password - can be left empty
+#pass		mithrandir
+
+## - Character name (this is only for the 'fullauto' feature further below)
+#name		Gandalf
+
+## - Meta server providing a list of game servers
+##   leave commented out to use default (meta.tomenet.eu)
+#meta		meta.tomenet.eu
+
+## - Server and port you wish to connect to;
+##   leave commented out to get a list of servers
+#server		europe.tomenet.eu
+#port		18348
+
+## - Perform automatic login with nick, pass and also character name
+#fullauto
+
+# Use lighter 'dark blue' colour to increase readability on some screens
+# Sets blue to #0033ff instead of #0000ff
+lighterDarkBlue
+window_decorations	0
+
+# Full color remapping (except 0 aka black, which is immutable)
+# 0 = black, 1 = white, 2 = gray, 3 = orange, 4 = red, 5 = green, 6 = blue
+# 7 = umber, 8 = dark gray, 9 = light gray, 10 = violet, 11 = yellow
+# 12 = light red, 13 = light green, 14 = light blue, 15 = light umber
+#colormap_0		#000000
+#colormap_1		#ffffff
+#colormap_2		#9d9d9d
+#colormap_3		#ff8d00
+#colormap_4		#b70000
+#colormap_5		#009d44
+#colormap_6		#0000ff
+#colormap_7		#8d6600
+#colormap_8		#666666
+#colormap_9		#cdcdcd
+#colormap_10		#af00ff
+#colormap_11		#ffff00
+#colormap_12		#ff3030
+#colormap_13		#00ff00
+#colormap_14		#00ffff
+#colormap_15		#c79d55
+
+
+
+## Miscellaneous settings
+
+## - Client fps (defaults to 100, best left disabled)
+#fps		100
+
+## - Your unix user name (best left disabled)
+#realname	xxx
+
+## - Your TomeNET path (best left disabled)
+#path		xxx
+
+
+
+## Graphics settings
+
+## - Enable graphics in general (0 = off. 1 = on, 2 = dual-mask mode)
+graphics	0
+
+## - Specify basename for loaded graphics file and possible custom graphics character redefinitions.
+##   If "graphics" option is enabled, the tiles can be loaded from lib/xtra/graphics/{graphic_tiles}.bmp (Eg: lib/xtra/graphics/8x8.bmp).
+##   The character redefinitions are loaded from lib/user/graphics-{os}.prf (the "{os}" is replaced by "x11", "win", "mac", ...)
+##   or from a custom graphics redefinition file lib/user/graphics-{graphic_tiles}.prf, if the file exists.
+##
+##   Important: The value has to be in format "{int width}x{int height}[{string}]", because tile width and height is extracted from the string.
+graphic_tiles 16x24sv
+
+## - Disable cache for graphics tiles? (Not recommended, basically just slows down drawing)
+##   Set to '0' to keep the the cache enabled, 1 to disable the cache.
+disableGfxCache 0
+
+
+
+## Audio settings
+
+## - Enable audio in general (0 = off, 1 = on)
+sound			1
+
+## - Pre-cache audio (defaults to on; recommended)
+#cacheAudio		1
+
+## - Mixer sample rate, default is 44100 (best left disabled)
+##   It is highly recommended to not changed this to
+##   avoid wrongly pitched audio on some systems.
+#audioSampleRate	44100
+
+## - Number of mixer channels, ie the number of sound effects
+##   that can be played simultaneously. (4..32)
+#audioChannels		32
+
+## - Sample buffer size (larger = more lagging sound,
+##   smaller = skipping on slow machines. 128..8192)
+audioBuffer		1024
+
+## - Subfolders within lib/xtra folder that contain audio packs
+soundpackFolder		sound
+musicpackFolder		music
+
+## - Turn various things on(1) or off(0)
+audioMaster		1
+audioMusic		1
+audioSound		1
+audioWeather		1
+
+## - Mixer values for various things (0..100)
+audioVolumeMaster	70
+audioVolumeMusic	70
+audioVolumeSound	70
+audioVolumeWeather	70
+
+
+
+## Window settings
+## - Set visibility, position (if supported), size and font of all windows.
+##   Possible fonts (depending on your system) might be for example:
+##   4x6, 5x7, 5x8, 6x9, 6x10, 6x12, 7x13, 7x14, 8x13, 9x15, 10x20, 12x24.
+
+## 'TomeNET' Main window
+Term-Main_X		0
+Term-Main_Y		0
+Term-Main_Columns	80
+Term-Main_Lines		24
+Term-Main_Font		8x13
+
+## 'Msg/Chat' Term-1 window
+Term-1_Title		Msg/Chat
+Term-1_Visible		1
+Term-1_X		0
+Term-1_Y		0
+Term-1_Columns		80
+Term-1_Lines		24
+Term-1_Font		6x10
+
+## 'Inventory' Term-2 window
+Term-2_Title		Inventory
+Term-2_Visible		1
+Term-2_X		0
+Term-2_Y		0
+Term-2_Columns		80
+Term-2_Lines		24
+Term-2_Font		6x10
+
+## 'Character' Term-3 window
+Term-3_Title		Character
+Term-3_Visible		1
+Term-3_X		0
+Term-3_Y		0
+Term-3_Columns		80
+Term-3_Lines		24
+Term-3_Font		5x8
+
+## 'Chat' term-4
+Term-4_Title		Chat
+Term-4_Visible		1
+Term-4_X		0
+Term-4_Y		0
+Term-4_Columns		80
+Term-4_Lines		24
+Term-4_Font		6x10
+
+## 'Equipment' term-5
+Term-5_Title		Equipment
+Term-5_Visible		1
+Term-5_X		0
+Term-5_Y		0
+Term-5_Columns		80
+Term-5_Lines		14
+Term-5_Font		5x8
+
+## 'Bags', term-6
+Term-6_Title		Bags
+Term-6_Visible		1
+Term-6_X		0
+Term-6_Y		0
+Term-6_Columns		80
+Term-6_Lines		13
+Term-6_Font		5x8
+
+## unnamed, term-7
+Term-7_Title		Term-7
+Term-7_Visible		0
+Term-7_X		0
+Term-7_Y		0
+Term-7_Columns		80
+Term-7_Lines		24
+Term-7_Font		5x8
+
+## unnamed, term-8
+Term-8_Title		Term-8
+Term-8_Visible		0
+Term-8_X		0
+Term-8_Y		0
+Term-8_Columns		80
+Term-8_Lines		24
+Term-8_Font		5x8
+
+## unnamed, term-9
+Term-9_Title		Term-9
+Term-9_Visible		0
+Term-9_X		0
+Term-9_Y		0
+Term-9_Columns		80
+Term-9_Lines		24
+Term-9_Font		5x8


### PR DESCRIPTION
## Summary
- decouple `tomenet.cfg` from `.tomenetrc` and add a new `window_decorations` option
- read and write `window_decorations` in the SDL2 client
- create SDL windows with or without borders based on the setting
- allow toggling window decorations at runtime via the font/visibility menu

## Testing
- `make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_686e02924f408332b1b5720e8e684e67