### PR TITLE
Improve SDL2 font detection

### DIFF
--- a/src/client/externs.h
+++ b/src/client/externs.h
@@ -59,6 +59,7 @@ extern void refresh_palette(void);
 extern int get_misc_fonts(char *output_list, int max_misc_fonts, int max_font_name_length, int max_fonts);
 extern void set_window_title_sdl2(int term_idx, cptr title);
 extern void apply_window_decorations(void);
+extern bool is_pcf_font(const char *name);
 
 extern char *SDL2_USER_PATH, *SDL2_GAME_PATH;
 extern char SDL2_PATH_SEP[2];

--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -536,13 +536,12 @@ static errr Infofnt_init_pcf(cptr name) {
  *	name: The name of the requested Font
  */
 static errr Infofnt_init(cptr name) {
-	// Detect true type font.
-	if (strstr(name, ".ttf") != NULL) {
-		return Infofnt_init_ttf(name);
-	}
+        /* TrueType fonts are assumed unless the file name denotes a PCF font. */
+        if (!is_pcf_font(name)) {
+                return Infofnt_init_ttf(name);
+        }
 
-	// Assume this is a .pcf monospaced bitmap font.
-	return Infofnt_init_pcf(name);
+        return Infofnt_init_pcf(name);
 }
 
 /*
@@ -2340,8 +2339,8 @@ static int term_data_to_term_idx(term_data *td) {
  * If provided font is a .ttf and size is missing or out of bounds, add or fix the font size.
  */
 static void validate_font_format(char *font, int term_idx) {
-	if (!font) return;
-	if (strstr(font, ".ttf") != NULL) {
+        if (!font) return;
+        if (!is_pcf_font(font)) {
 		char name[256];
 		int size;
 		int n = sscanf(font, "%255s %d", name, &size);


### PR DESCRIPTION
## Summary
- add `is_pcf_font` helper to detect PCF fonts reliably
- use the helper when scanning fonts and when forcing font sizes
- default to TTF when font is not detected as PCF
- export the helper in `externs.h`

## Testing
- `make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_6871f6a22d7083328a1f6685c8b62e44