### PR TITLE
Fix surface cleanup in PCF_RenderText

### DIFF
--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -4037,6 +4037,7 @@ SDL_Surface* PCF_RenderText(struct PCF_Font* font, const char* str, SDL_Color fg
 	preparation = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL_PIXELFORMAT_RGBA32);
 	if (!preparation) {
 		fprintf(stderr, "PCF_RenderText: Error creating preparation surface: %s\n", TTF_GetError());
+		SDL_FreeSurface(surface);
 		return NULL;
 	}
 	// Fill the preparation surface with foreground color.


### PR DESCRIPTION
## Summary
- free created surface when preparation surface creation fails

## Testing
- `make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_6873310bd98c8332ac3525cd025bb6e9