### PR TITLE
Fix PCF encoding check in SDL2 font loader

### DIFF
--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -3805,7 +3805,7 @@ static PCF_Font* PCF_OpenFont(const char *name) {
 	max_byte1 = pcf_readS16(f, encodingsFormat);
 	default_char = pcf_readS16(f, encodingsFormat);
 
-	if (min_byte1 != max_byte1 != 0) {
+	if (min_byte1 != 0 || max_byte1 != 0 || min_byte1 != max_byte1) {
 		//For single byte encodings min_byte1==max_byte1==0, and encoded values are between [min_char_or_byte2,max_char_or_byte2]. The glyph index corresponding to an encoding is glyphindex[encoding-min_char_or_byte2].
 		fprintf(stderr, "Error: Only single byte encodings are supported.\n");
 		PCF_CloseFont(font);


### PR DESCRIPTION
## Summary
- correct the byte comparison in the SDL2 PCF font loader
- ensure build succeeds

## Testing
- `make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_68733161dbf48332a95ef124d073d01f