### PR TITLE
Remove x11_refresh delays for SDL2

### DIFF
--- a/src/client/c-util.c
+++ b/src/client/c-util.c
@@ -11220,12 +11220,11 @@ static void do_cmd_options_fonts(void) {
 	char graphic_font_name[MAX_FONTS][256];
 	int graphic_fonts = 0;
 
-   #ifndef WINDOWS
-  //TODO jezek - Do we need x11_refresh with sdl2?
-	int x11_refresh = 50;
-	FILE *fff;
-   #else
-	char *cp, *cpp;
+   #ifdef USE_X11
+        int x11_refresh = 50;
+        FILE *fff;
+   #elif defined(WINDOWS)
+        char *cp, *cpp;
    #endif
 
    #ifdef WINDOWS /* Windows uses the .FON files */
@@ -11583,9 +11582,8 @@ static void do_cmd_options_fonts(void) {
 				} else {
 					for (j = 0; j < graphic_fonts - 1; j++) {
 						if (!strcasecmp(graphic_font_name[j], get_font_name(y))) {
-							set_font_name(y, graphic_font_name[j + 1]);
-							sync_sleep(x11_refresh);
-							break;
+                                                set_font_name(y, graphic_font_name[j + 1]);
+                                                break;
 						}
 					}
 				}
@@ -11604,8 +11602,8 @@ static void do_cmd_options_fonts(void) {
 				for (j = 0; j < graphic_fonts - 1; j++) {
 					if (!strcasecmp(graphic_font_name[j], get_font_name(y))) {
 						set_font_name(y, graphic_font_name[j + 1]);
-   #ifndef WINDOWS
-						sync_sleep(x11_refresh);
+   #ifdef USE_X11
+                                                sync_sleep(x11_refresh);
    #endif
 						break;
 					}
@@ -11614,8 +11612,8 @@ static void do_cmd_options_fonts(void) {
 					for (j = 0; j < fonts - 1; j++) {
 						if (!strcasecmp(font_name[j], get_font_name(y))) {
 							set_font_name(y, font_name[j + 1]);
-   #ifndef WINDOWS
-							sync_sleep(x11_refresh);
+   #ifdef USE_X11
+                                                        sync_sleep(x11_refresh);
    #endif
 							break;
 						}
@@ -11646,9 +11644,8 @@ static void do_cmd_options_fonts(void) {
 				} else {
 					for (j = 1; j < graphic_fonts; j++) {
 						if (!strcasecmp(graphic_font_name[j], get_font_name(y))) {
-							set_font_name(y, graphic_font_name[j - 1]);
-							sync_sleep(x11_refresh);
-							break;
+                                                set_font_name(y, graphic_font_name[j - 1]);
+                                                break;
 						}
 					}
 				}
@@ -11667,8 +11664,8 @@ static void do_cmd_options_fonts(void) {
 				for (j = 1; j < graphic_fonts; j++) {
 					if (!strcasecmp(graphic_font_name[j], get_font_name(y))) {
 						set_font_name(y, graphic_font_name[j - 1]);
-   #ifndef WINDOWS
-						sync_sleep(x11_refresh);
+   #ifdef USE_X11
+                                                sync_sleep(x11_refresh);
    #endif
 						break;
 					}
@@ -11677,8 +11674,8 @@ static void do_cmd_options_fonts(void) {
 					for (j = 1; j < fonts; j++) {
 						if (!strcasecmp(font_name[j], get_font_name(y))) {
 							set_font_name(y, font_name[j - 1]);
-   #ifndef WINDOWS
-							sync_sleep(x11_refresh);
+   #ifdef USE_X11
+                                                        sync_sleep(x11_refresh);
    #endif
 							break;
 						}
@@ -11712,8 +11709,8 @@ static void do_cmd_options_fonts(void) {
 			clear_from(20);
 			if (!tmp_name[0]) break;
 			set_font_name(y, tmp_name);
-   #ifndef WINDOWS
-			sync_sleep(x11_refresh);
+   #ifdef USE_X11
+                        sync_sleep(x11_refresh);
    #endif
 			break;
 


### PR DESCRIPTION
## Summary
- eliminate x11_refresh variable from SDL2 builds
- guard delay calls with `USE_X11`

## Testing
- `cd src && make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_68742f1f66c48332909d222c44598ec1