### PR TITLE
Optional SDL2_image support

### DIFF
--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -4,7 +4,9 @@
  * SDL2 bindings implementation for the TomeNET game project.
  * Handles window creation, event handling, keyboard input, and graphics/text output using SDL2.
  *
- * Note: Requires SDL2, SDL2_ttf and SDL2_image libraries.
+ * Note: Requires SDL2 and SDL2_ttf libraries.
+ * PNG screenshot functionality optionally uses SDL2_image when compiled
+ * with SDL2_IMAGE defined.
  */
 
 #include "angband.h"
@@ -17,7 +19,9 @@
  #include <SDL2/SDL.h>
  #include <SDL2/SDL_ttf.h>
  #include <SDL2/SDL_net.h>
- #include <SDL2/SDL_image.h>
+ #ifdef SDL2_IMAGE
+  #include <SDL2/SDL_image.h>
+ #endif
 #endif
 
 #include <stdio.h>
@@ -2635,12 +2639,14 @@ errr init_sdl2(void) {
                return(-1);
        }
 
+#ifdef SDL2_IMAGE
        if (!(IMG_Init(IMG_INIT_PNG) & IMG_INIT_PNG)) {
                fprintf(stderr, "ERROR: init_sdl2: IMG_Init error: %s\n", IMG_GetError());
                TTF_Quit();
                SDL_Quit();
                return(-1);
        }
+#endif
 
 	/* Initialize SDL_net */
 	if (SDLNet_Init() < 0) {
@@ -3508,6 +3514,10 @@ void set_window_title_sdl2(int term_idx, cptr title) {
 }
 
 errr sdl2_win_term_main_screenshot(cptr name) {
+#ifndef SDL2_IMAGE
+       plog("PNG screenshot support not available. Recompile with SDL2_image.");
+       return 1;
+#else
        if (!term_main.win || !term_main.win->surface) return 1;
 
        /* Ensure latest contents are displayed */
@@ -3525,6 +3535,7 @@ errr sdl2_win_term_main_screenshot(cptr name) {
 
        SDL_FreeSurface(conv);
        return 0;
+#endif
 }
 
 /* PCF definitions and handling functions. */

--- a/src/makefile.sdl2
+++ b/src/makefile.sdl2
@@ -13,7 +13,8 @@
 #
 # Flags:
 #
-#  - USE_SDL2 - Required for all SDL2 clients, uses SDL2, SDL2_ttf and SDL2_image libraries. Is set as default.
+#  - USE_SDL2 - Required for all SDL2 clients, uses SDL2 and SDL2_ttf libraries.
+#    PNG screenshot support additionally requires SDL2_image when available.
 #
 #  - SOUND_SDL - Optional, using SDL2_mixer library and provides SDL sound/music support. Is set as default.
 #
@@ -114,6 +115,27 @@ SDL_CONFIG_MINGW ?= /usr/$(MINGW_TARGET)/bin/sdl2-config
 #
 COMMON_FLAGS_LINUX := -std=c99 -pipe -Wall -fPIE -fsigned-char -DMEXP=19937 -D_XOPEN_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE -Iserver -Iserver/lua
 COMMON_FLAGS_MINGW := -flto=auto -Wall -DMEXP=19937 -std=c99 -DWINVER=0x0501 -DMINGW -Iserver -Iserver/lua
+
+# Check for SDL2_image library and set flags accordingly
+SDL2_IMAGE_CFLAGS_LINUX := $(shell $(PKG_CONFIG_LINUX) --cflags SDL2_image 2>/dev/null)
+SDL2_IMAGE_LIBS_LINUX := $(shell $(PKG_CONFIG_LINUX) --libs SDL2_image 2>/dev/null)
+SDL2_IMAGE_CFLAGS_MINGW := $(shell $(PKG_CONFIG_MINGW) --cflags SDL2_image 2>/dev/null)
+SDL2_IMAGE_LIBS_MINGW := $(shell $(PKG_CONFIG_MINGW) --libs SDL2_image 2>/dev/null)
+
+ifneq ($(SDL2_IMAGE_CFLAGS_LINUX),)
+  COMMON_FLAGS_LINUX += -DSDL2_IMAGE $(SDL2_IMAGE_CFLAGS_LINUX)
+  LIBS_SDL2_IMAGE_LINUX := $(SDL2_IMAGE_LIBS_LINUX)
+else
+  LIBS_SDL2_IMAGE_LINUX :=
+  $(warning Warning: SDL2_image not found, PNG screenshot support disabled)
+endif
+
+ifneq ($(SDL2_IMAGE_CFLAGS_MINGW),)
+  COMMON_FLAGS_MINGW += -DSDL2_IMAGE $(SDL2_IMAGE_CFLAGS_MINGW)
+  LIBS_SDL2_IMAGE_MINGW := $(SDL2_IMAGE_LIBS_MINGW)
+else
+  LIBS_SDL2_IMAGE_MINGW :=
+endif
 
 
 #TODO jezek - figure out how.
@@ -217,7 +239,7 @@ date:
 # Rules for building the TomeNET SDL2 (test) client
 #
 tomenet tomenet.test: CFLAGS = -Djezek_t $(COMMON_FLAGS_LINUX) -DUSE_SDL2 -DSOUND_SDL $(shell $(SDL_CONFIG_LINUX) --cflags)
-tomenet tomenet.test: LIBS = -lm -lSDL2_mixer -lSDL2_ttf -lSDL2_net -lSDL2_image $(shell $(SDL_CONFIG_LINUX) --libs)
+tomenet tomenet.test: LIBS = -lm -lSDL2_mixer -lSDL2_ttf -lSDL2_net $(LIBS_SDL2_IMAGE_LINUX) $(shell $(SDL_CONFIG_LINUX) --libs)
 # Compiler for lient gets additional security hardening flags (linker too)
 tomenet: CFLAGS += -fstack-protector -D_FORTIFY_SOURCE=2 -g -O2
 tomenet: $(CLI_OBJS_LINUX) $(CLI_LUAOBJS_LINUX) $(TOLUAOBJS_LINUX)
@@ -230,7 +252,7 @@ tomenet.test: $(CLI_OBJS_LINUX) $(CLI_LUAOBJS_LINUX) $(TOLUAOBJS_LINUX)
 	$(CC_LINUX) $(CFLAGS) -o tomenet $(CLI_OBJS_LINUX) $(CLI_LUAOBJS_LINUX) $(TOLUAOBJS_LINUX) $(LIBS)
 
 tomenet.exe tomenet.test.exe: CFLAGS = -Djezek_t $(COMMON_FLAGS_MINGW) -DUSE_SDL2 -DSOUND_SDL $(shell $(SDL_CONFIG_MINGW) --cflags)
-tomenet.exe tomenet.test.exe: LIBS = -lregex -lSDL2_mixer -lSDL2_ttf -lSDL2_net -lSDL2_image $(shell $(SDL_CONFIG_MINGW) --libs)
+tomenet.exe tomenet.test.exe: LIBS = -lregex -lSDL2_mixer -lSDL2_ttf -lSDL2_net $(LIBS_SDL2_IMAGE_MINGW) $(shell $(SDL_CONFIG_MINGW) --libs)
 # Compiler for lient gets additional security hardening flags (linker too)
 tomenet.exe: CFLAGS += -D_FORTIFY_SOURCE=2 -O2
 tomenet.exe: $(CLI_OBJS_MINGW) $(CLI_LUAOBJS_MINGW) $(TOLUAOBJS_MINGW)


### PR DESCRIPTION
## Summary
- make SDL2_image optional by detecting the library in `makefile.sdl2`
- wrap SDL_image code behind the new `SDL2_IMAGE` macro in `main-sdl2.c`
- inform the player when PNG screenshots are unavailable

## Testing
- `make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_687493a593b08332aab8b518f135142f