### PR TITLE
Fallback to BMP screenshots without SDL2_image

### DIFF
--- a/src/client/c-files.c
+++ b/src/client/c-files.c
@@ -13,6 +13,14 @@
  #include <regex.h>
 #endif
 
+#ifdef USE_SDL2
+ #ifdef SDL2_IMAGE
+  #define SDL2_SCREENSHOT_EXT "png"
+ #else
+  #define SDL2_SCREENSHOT_EXT "bmp"
+ #endif
+#endif
+
 
 /* Does WINDOWS client use the user's home folder instead of the TomeNET folder for 'scpt' and 'user' subfolders?
    This may be required in Windows 7 and higher, where access rights could cause problems when writing to these folders. - C. Blue */
@@ -2181,7 +2189,7 @@ void xhtml_screenshot(cptr name, byte redux) {
 	}
 
 #ifdef ENABLE_SHIFT_SPECIALKEYS
-	/* Hack: SHIFT+CTRL+T makes a real (PNG) screenshot instead of an xhtml screenshot - C. Blue */
+       /* Hack: SHIFT+CTRL+T makes a real screenshot (PNG or BMP) instead of an xhtml screenshot - C. Blue */
 	if ((!c_cfg.screenshot_keys && inkey_shift_special == 3) ||
 	    (c_cfg.screenshot_keys && inkey_shift_special != 3)) {
  #if defined(USE_X11)
@@ -2199,17 +2207,17 @@ void xhtml_screenshot(cptr name, byte redux) {
 			silent_dump = FALSE;
 			return;
 		}
- #elif defined(USE_SDL2)
-		//TODO jezek - Test PNG screenshot generations using shift special keys.
+#elif defined(USE_SDL2)
+               //TODO jezek - Test screenshot generation using shift special keys.
 		char buf2[1028];
 		strcpy(buf2, buf);
 		buf2[strlen(buf2) - 5] = 0;
 
-		if (sdl2_win_term_main_screenshot(format("%spng", buf2))) {
-			c_msg_format("Error: Failed to save screenshot of main term window to %spng", buf2);
-		} else {
-			if (!silent_dump) c_msg_format("Screenshot saved to %spng", buf2);
-		}
+               if (sdl2_win_term_main_screenshot(format("%s" SDL2_SCREENSHOT_EXT, buf2))) {
+                       c_msg_format("Error: Failed to save screenshot of main term window to %s" SDL2_SCREENSHOT_EXT, buf2);
+               } else {
+                       if (!silent_dump) c_msg_format("Screenshot saved to %s" SDL2_SCREENSHOT_EXT, buf2);
+               }
 		silent_dump = FALSE;
 		return;
  #elif defined(WINDOWS)


### PR DESCRIPTION
## Summary
- support saving BMP screenshots when SDL2_image isn't available
- adjust messages and file extensions for SDL2 screenshot feature

## Testing
- `make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_687573ce444c8332a130cc1e4e9a692b