### PR TITLE
Clean SDL2 net code from unused UDP layer

### DIFF
--- a/src/client/c-init.c
+++ b/src/client/c-init.c
@@ -4009,8 +4009,13 @@ again:
 #endif
 
 	/* Send the info */
-	if ((bytes = DgramWrite(Socket, ibuf.buf, ibuf.len) == -1))
-		quit("Couldn't send contact information\n");
+#ifdef USE_SDL2
+        if ((bytes = SocketWrite(Socket, ibuf.buf, ibuf.len)) == -1)
+                quit("Couldn't send contact information\n");
+#else
+        if ((bytes = DgramWrite(Socket, ibuf.buf, ibuf.len)) == -1)
+                quit("Couldn't send contact information\n");
+#endif
 
 	/* Listen for reply */
 	for (retries = 0; retries < 10; retries++) {
@@ -4021,7 +4026,11 @@ again:
 		if (!SocketReadable(Socket)) continue;
 
 		/* Read reply */
-		if (DgramRead(Socket, ibuf.buf, ibuf.size) <= 0) {
+#ifdef USE_SDL2
+                if (SocketRead(Socket, ibuf.buf, ibuf.size) <= 0) {
+#else
+                if (DgramRead(Socket, ibuf.buf, ibuf.size) <= 0) {
+#endif
 			/*printf("DgramReceiveAny failed (errno = %d)\n", errno);*/
 			continue;
 		}

--- a/src/client/nclient.c
+++ b/src/client/nclient.c
@@ -1499,13 +1499,23 @@ void Net_cleanup(void) {
 
 	if (sock > 2) {
 		ch = PKT_QUIT;
-		if (DgramWrite(sock, &ch, 1) != 1) {
-			GetSocketError(sock);
-			DgramWrite(sock, &ch, 1);
-		}
-		Term_xtra(TERM_XTRA_DELAY, 50);
+#ifdef USE_SDL2
+               if (SocketWrite(sock, &ch, 1) != 1) {
+                       GetSocketError(sock);
+                       SocketWrite(sock, &ch, 1);
+               }
+               Term_xtra(TERM_XTRA_DELAY, 50);
 
-		DgramClose(sock);
+               SocketClose(sock);
+#else
+               if (DgramWrite(sock, &ch, 1) != 1) {
+                       GetSocketError(sock);
+                       DgramWrite(sock, &ch, 1);
+               }
+               Term_xtra(TERM_XTRA_DELAY, 50);
+
+               DgramClose(sock);
+#endif
 	}
 
 	Sockbuf_cleanup(&rbuf);

--- a/src/common/net-sdl2.h
+++ b/src/common/net-sdl2.h
@@ -52,10 +52,8 @@ extern int	SetSocketSendBufferSize(int, int);
 extern int	SetSocketNoDelay(int, int);
 extern int	GetSocketError(int);
 extern int	SocketReadable(int);
+extern int      SocketWrite(int, char *, int);
 extern int	SocketRead(int, char *, int);
-extern int	DgramRead(int fd, char *rbuf, int size);
-extern int	DgramWrite(int fd, char *wbuf, int size);
-extern void	DgramClose(int);
 extern void	GetLocalHostName(char *, unsigned);
 extern int	SocketClose(int fd);
 

--- a/src/common/sockbuf.c
+++ b/src/common/sockbuf.c
@@ -227,7 +227,11 @@ int Sockbuf_flush(sockbuf_t *sbuf) {
 	    len = sbuf->len;
 	else
 #endif
-	while ((len = DgramWrite(sbuf->sock, sbuf->buf, sbuf->len)) <= 0) {
+	#ifdef USE_SDL2
+        while ((len = SocketWrite(sbuf->sock, sbuf->buf, sbuf->len)) <= 0) {
+#else
+        while ((len = DgramWrite(sbuf->sock, sbuf->buf, sbuf->len)) <= 0) {
+#endif
 	    if (len == 0
 		|| errno == EWOULDBLOCK
 		|| errno == EAGAIN) {
@@ -268,7 +272,11 @@ int Sockbuf_flush(sockbuf_t *sbuf) {
 	Sockbuf_clear(sbuf);
     } else {
 	errno = 0;
-	while ((len = DgramWrite(sbuf->sock, sbuf->buf, sbuf->len)) <= 0) {
+	#ifdef USE_SDL2
+        while ((len = SocketWrite(sbuf->sock, sbuf->buf, sbuf->len)) <= 0) {
+#else
+        while ((len = DgramWrite(sbuf->sock, sbuf->buf, sbuf->len)) <= 0) {
+#endif
 	    if (errno == EINTR) {
 		errno = 0;
 		continue;
@@ -341,7 +349,11 @@ int Sockbuf_read(sockbuf_t *sbuf) {
 	    len = sbuf->len;
 	else
 #endif
-	while ((len = DgramRead(sbuf->sock, sbuf->buf + sbuf->len, max)) <= 0) {
+	#ifdef USE_SDL2
+        while ((len = SocketRead(sbuf->sock, sbuf->buf + sbuf->len, max)) <= 0) {
+#else
+        while ((len = DgramRead(sbuf->sock, sbuf->buf + sbuf->len, max)) <= 0) {
+#endif
 	    if (len == 0) {
 		return(0);
 	    }
@@ -377,7 +389,11 @@ int Sockbuf_read(sockbuf_t *sbuf) {
 	sbuf->len += len;
     } else {
 	errno = 0;
-	while ((len = DgramRead(sbuf->sock, sbuf->buf + sbuf->len, max)) <= 0) {
+	#ifdef USE_SDL2
+        while ((len = SocketRead(sbuf->sock, sbuf->buf + sbuf->len, max)) <= 0) {
+#else
+        while ((len = DgramRead(sbuf->sock, sbuf->buf + sbuf->len, max)) <= 0) {
+#endif
 	    if (len == 0) {
 		return(0);
 	    }


### PR DESCRIPTION
## Summary
- drop unused UDP datagram helpers from the SDL2 network module
- update SDL2 client sources to call TCP helpers directly

## Testing
- `make -f makefile.sdl2 clean`
- `make -f makefile.sdl2 all`


------
https://chatgpt.com/codex/tasks/task_e_687946335c548332b8b89a143d0377c6