### PR TITLE
Remove SDL_net socket option stubs

### DIFF
--- a/src/client/c-init.c
+++ b/src/client/c-init.c
@@ -3632,7 +3632,11 @@ void client_init(char *argv1, bool skip) {
 	/* For in-client guide search */
 	init_guide();
 
-	GetLocalHostName(host_name, 80);
+#ifdef USE_SDL2
+        strncpy(host_name, "localhost", sizeof(host_name));
+#else
+        GetLocalHostName(host_name, 80);
+#endif
 
 	/* Set the "quit hook" */
 	if (!quit_aux) quit_aux = quit_hook;

--- a/src/client/nclient.c
+++ b/src/client/nclient.c
@@ -1451,14 +1451,16 @@ int Net_init(int fd) {
 	sock = fd;
 
 	wbuf.sock = sock;
-	if (SetSocketNoDelay(sock, 1) == -1) {
-		plog("Can't set TCP_NODELAY on socket");
-		return(-1);
-	}
-	if (SetSocketSendBufferSize(sock, CLIENT_SEND_SIZE + 256) == -1)
-		plog(format("Can't set send buffer size to %d: error %d", CLIENT_SEND_SIZE + 256, errno));
-	if (SetSocketReceiveBufferSize(sock, CLIENT_RECV_SIZE + 256) == -1)
-		plog(format("Can't set receive buffer size to %d", CLIENT_RECV_SIZE + 256));
+#ifndef USE_SDL2
+        if (SetSocketNoDelay(sock, 1) == -1) {
+                plog("Can't set TCP_NODELAY on socket");
+                return(-1);
+        }
+        if (SetSocketSendBufferSize(sock, CLIENT_SEND_SIZE + 256) == -1)
+                plog(format("Can't set send buffer size to %d: error %d", CLIENT_SEND_SIZE + 256, errno));
+        if (SetSocketReceiveBufferSize(sock, CLIENT_RECV_SIZE + 256) == -1)
+                plog(format("Can't set receive buffer size to %d", CLIENT_RECV_SIZE + 256));
+#endif
 
 	/* queue buffer, not a valid socket filedescriptor needed */
 	if (Sockbuf_init(&qbuf, -1, CLIENT_RECV_SIZE,
@@ -1500,10 +1502,9 @@ void Net_cleanup(void) {
 	if (sock > 2) {
 		ch = PKT_QUIT;
 #ifdef USE_SDL2
-		if (SocketWrite(sock, &ch, 1) != 1) {
-			GetSocketError(sock);
-			SocketWrite(sock, &ch, 1);
-		}
+                if (SocketWrite(sock, &ch, 1) != 1) {
+                        SocketWrite(sock, &ch, 1);
+                }
 		Term_xtra(TERM_XTRA_DELAY, 50);
 
 		SocketClose(sock);

--- a/src/common/net-sdl2.c
+++ b/src/common/net-sdl2.c
@@ -155,126 +155,9 @@ int GetPortNum(int fd)
 } /* GetPortNum */
 
 
-/*
- *******************************************************************************
- *
- *	SetSocketReceiveBufferSize()
- *
- *******************************************************************************
- * Description:
- *	Sets the receive buffer size for a socket.
- *
- * Input Parameters:
- *	fd	- The socket descriptor.
- *	size	- The desired buffer size.
- *
- * Output Parameters:
- *	None.
- *
- * Return Value:
- *	-1 on failure, 0 on success.
- *
- * Note:
- *	SDL_net does not support changing the socket buffer size. This is a stub.
- *
- */
-int SetSocketReceiveBufferSize(int fd, int size)
-{
-	(void)fd;
-	(void)size;
-	/* Not supported by SDL_net; return success */
-	return 0;
-} /* SetSocketReceiveBufferSize */
 
 
-/*
- *******************************************************************************
- *
- *	SetSocketSendBufferSize()
- *
- *******************************************************************************
- * Description:
- *	Sets the send buffer size for a socket.
- *
- * Input Parameters:
- *	fd	- The socket descriptor.
- *	size	- The desired buffer size.
- *
- * Output Parameters:
- *	None.
- *
- * Return Value:
- *	-1 on failure, 0 on success.
- *
- * Note:
- *	SDL_net does not support changing the socket buffer size. This is a stub.
- *
- */
-int SetSocketSendBufferSize(int fd, int size)
-{
-	(void)fd;
-	(void)size;
-	/* Not supported by SDL_net; return success */
-	return 0;
-} /* SetSocketSendBufferSize */
 
-
-/*
- *******************************************************************************
- *
- *	SetSocketNoDelay()
- *
- *******************************************************************************
- * Description:
- *	Sets the TCP_NODELAY option on a connected stream socket.
- *
- * Input Parameters:
- *	fd	- The socket descriptor.
- *	flag	- 1 to enable, 0 to disable.
- *
- * Output Parameters:
- *	None.
- *
- * Return Value:
- *	-1 on failure, 0 on success.
- *
- * Note:
- *	SDL_net does not support setting TCP_NODELAY. This is a stub.
- *
- */
-int SetSocketNoDelay(int fd, int flag)
-{
-	(void)fd;
-	(void)flag;
-	/* Not supported by SDL_net; return success */
-	return 0;
-} /* SetSocketNoDelay */
-
-
-/*
- *******************************************************************************
- *
- *	GetSocketError()
- *
- *******************************************************************************
- * Description:
- *	Clears and returns the socket error status.
- *
- * Input Parameters:
- *	fd	- The socket descriptor.
- *
- * Output Parameters:
- *	None.
- *
- * Return Value:
- *	Always returns 0 as SDL_net does not support per-socket error retrieval.
- *
- */
-int GetSocketError(int fd)
-{
-	(void)fd;
-	return 0;
-} /* GetSocketError */
 
 
 /*
@@ -404,42 +287,6 @@ int SocketWrite(int fd, char *wbuf, int size)
 
 	return bytes;
 } /* SocketWrite */
-
-
-/*
- *******************************************************************************
- *
-
-
-/*
- *******************************************************************************
- *
- *	GetLocalHostName()
- *
- *******************************************************************************
- * Description:
- *	Returns the Fully Qualified Domain Name (FQDN) for the local host.
- *
- * Input Parameters:
- *	name	- Pointer to an array to store the hostname.
- *	size	- Size of the array.
- *
- * Output Parameters:
- *	The hostname is copied into the provided array.
- *
- * Return Value:
- *	None.
- *
- * Note:
- *	As SDL_net does not provide a native method to obtain the local host name,
- *	this implementation uses a fallback value.
- *
- */
-void GetLocalHostName(char *name, unsigned size)
-{
-	strncpy(name, "localhost", size);
-	name[size - 1] = '\0';
-} /* GetLocalHostName */
 
 
 /*

--- a/src/common/net-sdl2.h
+++ b/src/common/net-sdl2.h
@@ -47,14 +47,9 @@
 extern void	SetTimeout(int, int);
 extern int	CreateClientSocket(char *, int);
 extern int	GetPortNum(int);
-extern int	SetSocketReceiveBufferSize(int, int);
-extern int	SetSocketSendBufferSize(int, int);
-extern int	SetSocketNoDelay(int, int);
-extern int	GetSocketError(int);
 extern int	SocketReadable(int);
 extern int	SocketWrite(int, char *, int);
 extern int	SocketRead(int, char *, int);
-extern void	GetLocalHostName(char *, unsigned);
 extern int	SocketClose(int fd);
 
  #if !defined(select) && defined(__linux__)

--- a/src/common/sockbuf.c
+++ b/src/common/sockbuf.c
@@ -259,10 +259,12 @@ int Sockbuf_flush(sockbuf_t *sbuf) {
 					/*plog(format("send (%d)", i));*/
 				}
 			}
-			if (GetSocketError(sbuf->sock) == -1) {
-				plog("GetSocketError send");
-				return(-1);
-			}
+                        #ifndef USE_SDL2
+                        if (GetSocketError(sbuf->sock) == -1) {
+                                plog("GetSocketError send");
+                                return(-1);
+                        }
+                        #endif
 			errno = 0;
 		}
 		if (len != sbuf->len) {
@@ -382,10 +384,12 @@ int Sockbuf_read(sockbuf_t *sbuf) {
 					/*plog(format("recv (%d)", i));*/
 				}
 			}
-			if (GetSocketError(sbuf->sock) == -1) {
-				plog("GetSocketError recv");
-				return(-1);
-			}
+                        #ifndef USE_SDL2
+                        if (GetSocketError(sbuf->sock) == -1) {
+                                plog("GetSocketError recv");
+                                return(-1);
+                        }
+                        #endif
 			errno = 0;
 		}
 		sbuf->len += len;


### PR DESCRIPTION
## Summary
- drop unimplementable socket-option functions from SDL2 networking
- guard calls to removed functions behind `#ifndef USE_SDL2`
- simplify hostname retrieval for SDL2 builds

## Testing
- `make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_687ac10a4ff88332a028f09ded57b9b4