### PR TITLE
Implement SDL2 socket error tracking

### DIFF
--- a/src/common/net-sdl2.c
+++ b/src/common/net-sdl2.c
@@ -42,6 +42,8 @@ int sl_timeout_us = DEFAULT_US_TIMEOUT_VALUE;
 /* Mapping table for TCPsocket pointers */
 #define MAX_TCP_FD 1024
 static TCPsocket tcp_socket_table[MAX_TCP_FD] = { NULL };
+static int tcp_error_table[MAX_TCP_FD] = { 0 };
+static int create_error = 0;
 
 
 
@@ -100,23 +102,28 @@ void SetTimeout(int s, int us)
  */
 int CreateClientSocket(char *host, int port)
 {
-	IPaddress ip;
-	if (SDLNet_ResolveHost(&ip, host, port) < 0) {
-		sl_errno = SL_EHOSTNAME;
-		return -1;
-	}
-	TCPsocket sock = SDLNet_TCP_Open(&ip);
-	if (sock == NULL) {
-		sl_errno = SL_ESOCKET;
-		return -1;
-	}
-	int fd = addTCPsocket(sock);
-	if (fd == -1) {
-		SDLNet_TCP_Close(sock);
-		sl_errno = SL_EBIND;
-		return -1;
-	}
-	return fd;
+       IPaddress ip;
+       create_error = 0;
+       if (SDLNet_ResolveHost(&ip, host, port) < 0) {
+               sl_errno = SL_EHOSTNAME;
+               create_error = sl_errno;
+               return -1;
+       }
+       TCPsocket sock = SDLNet_TCP_Open(&ip);
+       if (sock == NULL) {
+               sl_errno = SL_ESOCKET;
+               create_error = sl_errno;
+               return -1;
+       }
+       int fd = addTCPsocket(sock);
+       if (fd == -1) {
+               SDLNet_TCP_Close(sock);
+               sl_errno = SL_EBIND;
+               create_error = sl_errno;
+               return -1;
+       }
+       tcp_error_table[fd] = 0;
+       return fd;
 } /* CreateClientSocket */
 
 
@@ -141,17 +148,23 @@ int CreateClientSocket(char *host, int port)
  */
 int GetPortNum(int fd)
 {
-	TCPsocket sock = fd2TCPsocket(fd);
-	if (sock == NULL) {
-		return -1;
-	}
-	IPaddress *ip = SDLNet_TCP_GetPeerAddress(sock);
-	if (ip == NULL) {
-		return -1;
-	}
-	/* ip->port is in network byte order; convert to host order */
-	Uint16 port = SDL_SwapBE16(ip->port);
-	return port;
+       TCPsocket sock = fd2TCPsocket(fd);
+       if (sock == NULL) {
+               sl_errno = SL_ESOCKET;
+               if ((fd >= 0) && (fd < MAX_TCP_FD))
+                       tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
+       IPaddress *ip = SDLNet_TCP_GetPeerAddress(sock);
+       if (ip == NULL) {
+               sl_errno = SL_ESOCKET;
+               tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
+       /* ip->port is in network byte order; convert to host order */
+       Uint16 port = SDL_SwapBE16(ip->port);
+       tcp_error_table[fd] = 0;
+       return port;
 } /* GetPortNum */
 
 
@@ -179,8 +192,14 @@ int GetPortNum(int fd)
  */
 int GetSocketError(int fd)
 {
-	(void)fd;
-	return 0;
+       if ((fd >= 0) && (fd < MAX_TCP_FD)) {
+               sl_errno = tcp_error_table[fd];
+               tcp_error_table[fd] = 0;
+       } else {
+               sl_errno = create_error;
+               create_error = 0;
+       }
+       return 0;
 } /* GetSocketError */
 
 
@@ -205,30 +224,41 @@ int GetSocketError(int fd)
  */
 int SocketReadable(int fd)
 {
-	TCPsocket sock = fd2TCPsocket(fd);
-	if (sock == NULL) {
-		return -1;
-	}
-	SDLNet_SocketSet set = SDLNet_AllocSocketSet(1);
-	if (set == NULL) {
-		return -1;
-	}
-	if (SDLNet_TCP_AddSocket(set, sock) == -1) {
-		SDLNet_FreeSocketSet(set);
-		return -1;
-	}
+       TCPsocket sock = fd2TCPsocket(fd);
+       if (sock == NULL) {
+               sl_errno = SL_ESOCKET;
+               if ((fd >= 0) && (fd < MAX_TCP_FD))
+                       tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
+       SDLNet_SocketSet set = SDLNet_AllocSocketSet(1);
+       if (set == NULL) {
+               sl_errno = SL_ESOCKET;
+               tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
+       if (SDLNet_TCP_AddSocket(set, sock) == -1) {
+               SDLNet_FreeSocketSet(set);
+               sl_errno = SL_ESOCKET;
+               tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
 	/* Calculate timeout in milliseconds */
 	int timeout_ms = sl_timeout_s * 1000 + sl_timeout_us / 1000;
-	int ret = SDLNet_CheckSockets(set, timeout_ms);
-	SDLNet_DelSocket(set, (SDLNet_GenericSocket)sock);
-	SDLNet_FreeSocketSet(set);
-	if (ret > 0) {
-		return 1;
-	} else if (ret == 0) {
-		return 0;
-	} else {
-		return -1;
-	}
+       int ret = SDLNet_CheckSockets(set, timeout_ms);
+       SDLNet_DelSocket(set, (SDLNet_GenericSocket)sock);
+       SDLNet_FreeSocketSet(set);
+       if (ret > 0) {
+               tcp_error_table[fd] = 0;
+               return 1;
+       } else if (ret == 0) {
+               tcp_error_table[fd] = 0;
+               return 0;
+       } else {
+               sl_errno = SL_ERECEIVE;
+               tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
 } /* SocketReadable */
 
 
@@ -255,18 +285,26 @@ int SocketReadable(int fd)
  */
 int SocketRead(int fd, char *buf, int size)
 {
-	if (SocketReadable(fd) <= 0) {
-		return -1;
-	}
-	TCPsocket sock = fd2TCPsocket(fd);
-	if (sock == NULL) {
-		return -1;
-	}
-	int bytes = SDLNet_TCP_Recv(sock, buf, size);
-	if (bytes <= 0) {
-		return -1;
-	}
-	return bytes;
+       if (SocketReadable(fd) <= 0) {
+               sl_errno = SL_ERECEIVE;
+               if ((fd >= 0) && (fd < MAX_TCP_FD))
+                       tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
+       TCPsocket sock = fd2TCPsocket(fd);
+       if (sock == NULL) {
+               sl_errno = SL_ESOCKET;
+               tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
+       int bytes = SDLNet_TCP_Recv(sock, buf, size);
+       if (bytes <= 0) {
+               sl_errno = SL_ERECEIVE;
+               tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
+       tcp_error_table[fd] = 0;
+       return bytes;
 } /* SocketRead */
 
 
@@ -293,23 +331,29 @@ int SocketRead(int fd, char *buf, int size)
  */
 int SocketWrite(int fd, char *wbuf, int size)
 {
-	/* Retrieve the TCP socket from the mapping table */
-	TCPsocket sock = fd2TCPsocket(fd);
-	if (sock == NULL) {
-		return -1;
-	}
+       /* Retrieve the TCP socket from the mapping table */
+       TCPsocket sock = fd2TCPsocket(fd);
+       if (sock == NULL) {
+               sl_errno = SL_ESOCKET;
+               if ((fd >= 0) && (fd < MAX_TCP_FD))
+                       tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
 
 	/* Send data over the TCP socket */
-	int bytes = SDLNet_TCP_Send(sock, wbuf, size);
+       int bytes = SDLNet_TCP_Send(sock, wbuf, size);
 
 	/* Check if the send operation was successful.
 	 * If bytes sent is less than the requested size, treat it as an error.
 	 */
-	if (bytes < size) {
-		return -1;
-	}
+       if (bytes < size) {
+               sl_errno = SL_ECONNECT;
+               tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
 
-	return bytes;
+       tcp_error_table[fd] = 0;
+       return bytes;
 } /* SocketWrite */
 
 
@@ -365,13 +409,17 @@ void GetLocalHostName(char *name, unsigned size)
  */
 int SocketClose(int fd)
 {
-	TCPsocket sock = fd2TCPsocket(fd);
-	if (sock == NULL) {
-		return -1;
-	}
-	SDLNet_TCP_Close(sock);
-	delTCPsocket(fd);
-	return 1;
+       TCPsocket sock = fd2TCPsocket(fd);
+       if (sock == NULL) {
+               sl_errno = SL_ECLOSE;
+               if ((fd >= 0) && (fd < MAX_TCP_FD))
+                       tcp_error_table[fd] = sl_errno;
+               return -1;
+       }
+       SDLNet_TCP_Close(sock);
+       delTCPsocket(fd);
+       tcp_error_table[fd] = 0;
+       return 1;
 } /* SocketClose */
 
 /*
@@ -396,13 +444,14 @@ int SocketClose(int fd)
  */
 static int addTCPsocket(TCPsocket sock)
 {
-	for (int i = 0; i < MAX_TCP_FD; i++) {
-		if (tcp_socket_table[i] == NULL) {
-			tcp_socket_table[i] = sock;
-			return i;
-		}
-	}
-	return -1; /* Table is full */
+       for (int i = 0; i < MAX_TCP_FD; i++) {
+               if (tcp_socket_table[i] == NULL) {
+                       tcp_socket_table[i] = sock;
+                       tcp_error_table[i] = 0;
+                       return i;
+               }
+       }
+       return -1; /* Table is full */
 }
 
 /*
@@ -424,8 +473,9 @@ static TCPsocket fd2TCPsocket(int fd)
  */
 static void delTCPsocket(int fd)
 {
-	if ((fd >= 0) && (fd < MAX_TCP_FD)) {
-		tcp_socket_table[fd] = NULL;
-	}
+       if ((fd >= 0) && (fd < MAX_TCP_FD)) {
+               tcp_socket_table[fd] = NULL;
+               tcp_error_table[fd] = 0;
+       }
 }
 


### PR DESCRIPTION
## Summary
- implement per-socket error tracking for SDL2 networking
- propagate `sl_errno` in SDL2 networking code
- record errors per file descriptor and provide them via `GetSocketError`

## Testing
- `cd src && make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_687c05da9628833285655b5a7e864f06