### PR TITLE
Resolve localhost name using SDLNet

### DIFF
--- a/src/common/net-sdl2.c
+++ b/src/common/net-sdl2.c
@@ -405,8 +405,20 @@ int SocketWrite(int fd, char *wbuf, int size)
  */
 void GetLocalHostName(char *name, unsigned size)
 {
-	strncpy(name, "127.0.0.1", size);
-	name[size - 1] = '\0';
+	IPaddress addrs[1];
+	const char *host = NULL;
+
+	if (SDLNet_GetLocalAddresses(addrs, 1) == 1) {
+		host = SDLNet_ResolveIP(&addrs[0]);
+	}
+
+	if (host && *host) {
+		strncpy(name, host, size);
+		name[size - 1] = '\0';
+	} else {
+		strncpy(name, "127.0.0.1", size);
+		name[size - 1] = '\0';
+	}
 } /* GetLocalHostName */
 
 


### PR DESCRIPTION
## Summary
- enhance `GetLocalHostName` in the SDL2 networking module
- call `SDLNet_GetLocalAddresses`/`SDLNet_ResolveIP` to resolve the hostname
- fall back to `127.0.0.1` when lookup fails

## Testing
- `make -f makefile.sdl2 all`

------
https://chatgpt.com/codex/tasks/task_e_687fd0f262c08332a2026ccbea018bc2