### PR TITLE
Use SDL2-specific user directories for file operations

### DIFF
--- a/src/client/c-birth.c
+++ b/src/client/c-birth.c
@@ -2511,7 +2511,13 @@ bool get_server_name(void) {
 		strcat(buf, "\\__ping.tmp");
 	} else
  #endif
-	path_build(buf, 1024, ANGBAND_DIR_USER, "__ping.tmp");
+        path_build(buf, 1024,
+#ifdef USE_SDL2
+                os_temp_path,
+#else
+                ANGBAND_DIR_USER,
+#endif
+                "__ping.tmp");
  #ifdef WINDOWS
 	meta_pings_xpath[0] = 0;
 	r = system(format("ping /? > %s 2>&1", buf));
@@ -2682,7 +2688,13 @@ bool get_server_name(void) {
 				strcat(path, format("\\__ping_%s.tmp", meta_pings_server_name[i]));
 			} else
    #endif
-			path_build(path, 1024, ANGBAND_DIR_USER, format("__ping_%s.tmp", meta_pings_server_name[j]));
+                        path_build(path, 1024,
+#ifdef USE_SDL2
+                                os_temp_path,
+#else
+                                ANGBAND_DIR_USER,
+#endif
+                                format("__ping_%s.tmp", meta_pings_server_name[j]));
 			fhan[j] = CreateFile(path,
 			    FILE_WRITE_DATA, //FILE_APPEND_DATA,
    #if 0
@@ -2735,7 +2747,13 @@ bool get_server_name(void) {
 					strcat(path, format("\\__ping_%s.tmp", meta_pings_server_name[i]));
 				} else
  #endif
-				path_build(path, 1024, ANGBAND_DIR_USER, format("__ping_%s.tmp", meta_pings_server_name[i]));
+                              path_build(path, 1024,
+#ifdef USE_SDL2
+                                      os_temp_path,
+#else
+                                      ANGBAND_DIR_USER,
+#endif
+                                      format("__ping_%s.tmp", meta_pings_server_name[i]));
 				remove(path);
 			}
  #if defined(WINDOWS) && defined(WINDOWS_USE_TEMP)
@@ -2746,7 +2764,13 @@ bool get_server_name(void) {
 				strcat(path, "\\__ping.tmp");
 			} else
  #endif
-			path_build(path, 1024, ANGBAND_DIR_USER, "__ping.tmp");
+                      path_build(path, 1024,
+#ifdef USE_SDL2
+                                os_temp_path,
+#else
+                                ANGBAND_DIR_USER,
+#endif
+                                "__ping.tmp");
 			remove(path);
 			meta_pings_servers = 0;
 #endif
@@ -2766,7 +2790,13 @@ bool get_server_name(void) {
 					strcat(path, format("\\__ping_%s.tmp", meta_pings_server_name[i]));
 				} else
  #endif
-				path_build(path, 1024, ANGBAND_DIR_USER, format("__ping_%s.tmp", meta_pings_server_name[i]));
+                              path_build(path, 1024,
+#ifdef USE_SDL2
+                                      os_temp_path,
+#else
+                                      ANGBAND_DIR_USER,
+#endif
+                                      format("__ping_%s.tmp", meta_pings_server_name[i]));
 				remove(path);
 			}
  #if defined(WINDOWS) && defined(WINDOWS_USE_TEMP)
@@ -2777,7 +2807,13 @@ bool get_server_name(void) {
 				strcat(path, "\\__ping.tmp");
 			} else
  #endif
-			path_build(path, 1024, ANGBAND_DIR_USER, "__ping.tmp");
+                      path_build(path, 1024,
+#ifdef USE_SDL2
+                                os_temp_path,
+#else
+                                ANGBAND_DIR_USER,
+#endif
+                                "__ping.tmp");
 			remove(path);
 			meta_pings_servers = 0;
 #endif
@@ -2803,7 +2839,13 @@ bool get_server_name(void) {
 			strcat(path, format("\\__ping_%s.tmp", meta_pings_server_name[i]));
 		} else
  #endif
-		path_build(path, 1024, ANGBAND_DIR_USER, format("__ping_%s.tmp", meta_pings_server_name[i]));
+              path_build(path, 1024,
+#ifdef USE_SDL2
+                        os_temp_path,
+#else
+                        ANGBAND_DIR_USER,
+#endif
+                        format("__ping_%s.tmp", meta_pings_server_name[i]));
 		remove(path);
 	}
  #if defined(WINDOWS) && defined(WINDOWS_USE_TEMP)
@@ -2814,7 +2856,13 @@ bool get_server_name(void) {
 		strcat(path, "\\__ping.tmp");
 	} else
  #endif
-	path_build(path, 1024, ANGBAND_DIR_USER, "__ping.tmp");
+      path_build(path, 1024,
+#ifdef USE_SDL2
+                os_temp_path,
+#else
+                ANGBAND_DIR_USER,
+#endif
+                "__ping.tmp");
 	remove(path);
 	meta_pings_servers = 0;
 #endif

--- a/src/client/c-init.c
+++ b/src/client/c-init.c
@@ -187,7 +187,11 @@ void init_stuff(void) {
 	/* Hack -- Validate the paths */
 	validate_dir(ANGBAND_DIR_SCPT);
 	validate_dir(ANGBAND_DIR_TEXT);
-	validate_dir(ANGBAND_DIR_USER);
+#ifdef USE_SDL2
+        validate_dir(ANGBAND_USER_DIR_USER);
+#else
+        validate_dir(ANGBAND_DIR_USER);
+#endif
 	validate_dir(ANGBAND_DIR_GAME);
 }
 #endif //not WINDOWS
@@ -3368,7 +3372,13 @@ static void quit_hook(cptr s) {
 	if (hist_chat_end || hist_chat_looped) {
 		FILE *fp;
 
-		path_build(buf, 1024, ANGBAND_DIR_USER, format("chathist-%s.tmp", nick));
+                path_build(buf, 1024,
+#ifdef USE_SDL2
+                        os_temp_path,
+#else
+                        ANGBAND_DIR_USER,
+#endif
+                        format("chathist-%s.tmp", nick));
 		fp = fopen(buf, "w");
 		if (fp) {
 			if (!hist_chat_looped) {
@@ -3391,7 +3401,13 @@ static void quit_hook(cptr s) {
 	{
 		FILE *fp;
 
-		path_build(buf, 1024, ANGBAND_DIR_USER, "bookmarks.tmp");
+                path_build(buf, 1024,
+#ifdef USE_SDL2
+                        os_temp_path,
+#else
+                        ANGBAND_DIR_USER,
+#endif
+                        "bookmarks.tmp");
 		fp = fopen(buf, "w");
 		if (fp) {
 			for (j = 0; j < GUIDE_BOOKMARKS; j++) {
@@ -3895,9 +3911,27 @@ again:
 		int x = 0;
 		char path[1024], path2[1024], pathbat[1024];
 
-		path_build(path, 1024, ANGBAND_DIR_USER, "__ipc");
-		path_build(path2, 1024, ANGBAND_DIR_USER, "__ipc_done");
-		path_build(pathbat, 1024, ANGBAND_DIR_USER, "__ipc.bat");
+        path_build(path, 1024,
+#ifdef USE_SDL2
+                os_temp_path,
+#else
+                ANGBAND_DIR_USER,
+#endif
+                "__ipc");
+        path_build(path2, 1024,
+#ifdef USE_SDL2
+                os_temp_path,
+#else
+                ANGBAND_DIR_USER,
+#endif
+                "__ipc_done");
+        path_build(pathbat, 1024,
+#ifdef USE_SDL2
+                os_temp_path,
+#else
+                ANGBAND_DIR_USER,
+#endif
+                "__ipc.bat");
 		fp = fopen(pathbat, "w");
 		if (fp) {
 			fprintf(fp, "ipconfig /all > %s\n", path);
@@ -4366,7 +4400,13 @@ again:
 
 	/* Remember chat input history across logins --
 	   ironically we 'reset message log' between logins in another place, not totally efficient.. */
-	path_build(buf, 1024, ANGBAND_DIR_USER, format("chathist-%s.tmp", nick));
+        path_build(buf, 1024,
+#ifdef USE_SDL2
+                os_temp_path,
+#else
+                ANGBAND_DIR_USER,
+#endif
+                format("chathist-%s.tmp", nick));
 	fp = fopen(buf, "r");
 	hist_chat_end = 0;
 	while (fp && hist_chat_end < MSG_HISTORY_MAX && my_fgets(fp, message_history_chat[hist_chat_end], MSG_LEN) == 0) hist_chat_end++;
@@ -4378,7 +4418,13 @@ again:
 
 #ifdef GUIDE_BOOKMARKS
 	/* Load guide bookmarks */
-	path_build(buf, 1024, ANGBAND_DIR_USER, "bookmarks.tmp");
+        path_build(buf, 1024,
+#ifdef USE_SDL2
+                os_temp_path,
+#else
+                ANGBAND_DIR_USER,
+#endif
+                "bookmarks.tmp");
 	fp = fopen(buf, "r");
 	temp = 0;
 	while (fp && temp < GUIDE_BOOKMARKS && fscanf(fp, "%d,%s\n", &bookmark_line[temp], bookmark_name[temp]) != EOF) temp++;

--- a/src/client/c-util.c
+++ b/src/client/c-util.c
@@ -3899,18 +3899,25 @@ byte get_3way(cptr prompt, bool default_no) {
 
 /* Kurzel reported that on Windows 10/11, printf() output is not shown in the terminal for unknown reason. So we need a log file, alternatively, as workaround: */
 void logprint(const char *out) {
-	static FILE *fp = NULL;
+        static FILE *fp = NULL;
+        char path[1024];
 
-	/* Atomic append, in case things go really wrong (paranoia) */
-	if (!fp) fp = fopen("tomenet-stdout.log", "w");
-	else fp = fopen("tomenet-stdout.log", "a");
+#ifdef USE_SDL2
+        path_build(path, 1024, os_temp_path, "tomenet-stdout.log");
+#else
+        strcpy(path, "tomenet-stdout.log");
+#endif
 
-	if (fp) {
-		fprintf(fp, "%s", out);
-		fclose(fp);
-	}
+        /* Atomic append, in case things go really wrong (paranoia) */
+        if (!fp) fp = fopen(path, "w");
+        else fp = fopen(path, "a");
 
-	printf("%s", out);
+        if (fp) {
+                fprintf(fp, "%s", out);
+                fclose(fp);
+        }
+
+        printf("%s", out);
 }
 
 
@@ -4888,7 +4895,13 @@ void c_msg_print(cptr msg) {
 		char path[1024];
 
 		/* Build the filename */
-		path_build(path, 1024, ANGBAND_DIR_USER, "stdout.txt");
+                path_build(path, 1024,
+#ifdef USE_SDL2
+                        os_temp_path,
+#else
+                        ANGBAND_DIR_USER,
+#endif
+                        "stdout.txt");
 
 		fp = my_fopen(path, "a");
 		/* success */
@@ -5619,7 +5632,11 @@ int macroset_scan(void) {
 	/* ---------- (b) Disk operations: Read macro files from TomeNET's user folder ---------- */
 
 	getcwd(cwd, sizeof(cwd)); //Remember TomeNET working directory
-	chdir(ANGBAND_DIR_USER); //Change to TomeNET user folder
+#ifdef USE_SDL2
+        chdir(ANGBAND_USER_DIR_USER); //Change to TomeNET user folder
+#else
+        chdir(ANGBAND_DIR_USER); //Change to TomeNET user folder
+#endif
 
 	/* For cyclic sets: These don't have keys to switch to each stage, but only 1 key that switches to the next stage.
 	   So to actually find all stages of a cyclic set, we therefore need to scan for all actually existing stage-filenames derived from the base filename.

--- a/src/client/nclient.c
+++ b/src/client/nclient.c
@@ -8171,7 +8171,13 @@ static void do_meta_pings(void) {
 			strcat(path, format("\\__ping_%s.tmp", meta_pings_server_name[i]));
 		} else
 #endif
-		path_build(path, 1024, ANGBAND_DIR_USER, format("__ping_%s.tmp", meta_pings_server_name[i]));
+                path_build(path, 1024,
+#ifdef USE_SDL2
+                        os_temp_path,
+#else
+                        ANGBAND_DIR_USER,
+#endif
+                        format("__ping_%s.tmp", meta_pings_server_name[i]));
 
 		/* Send a ping to each distinct server name, allowing for max 1000ms */
 		if (alt == 2) {

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -11,6 +11,7 @@
 
 #ifdef USE_SDL2
  #include "SDL2/SDL.h"
+ #include <sys/stat.h>
 #endif
 
 /*
@@ -317,16 +318,23 @@ void init_temp_path(void) {
 	else if ((c = getenv("TMPDIR"))) strcpy(os_temp_path, c);
 	else strcpy(os_temp_path, ".");
 #elif defined(USE_SDL2)
-	if ((c = getenv("TMPDIR"))) strcpy(os_temp_path, c);
-	else if ((c = getenv("TMP"))) strcpy(os_temp_path, c);
-	else if ((c = getenv("TEMPDIR"))) strcpy(os_temp_path, c);
-	else if ((c = getenv("TEMP"))) strcpy(os_temp_path, c);
-	else {
-		/* Use `temp` directory in SDL2 preferences location. */
-		strcpy(os_temp_path, SDL2_USER_PATH);
-		strcat(os_temp_path, "temp");
-		strcat(os_temp_path, SDL2_PATH_SEP);
-	}
+        if ((c = getenv("TMPDIR"))) strcpy(os_temp_path, c);
+        else if ((c = getenv("TMP"))) strcpy(os_temp_path, c);
+        else if ((c = getenv("TEMPDIR"))) strcpy(os_temp_path, c);
+        else if ((c = getenv("TEMP"))) strcpy(os_temp_path, c);
+        else {
+                /* Use `temp` directory in SDL2 preferences location. */
+                strcpy(os_temp_path, SDL2_USER_PATH);
+                strcat(os_temp_path, "temp");
+                strcat(os_temp_path, SDL2_PATH_SEP);
+        }
+        {
+                struct stat st;
+                char tmp[1024];
+                strcpy(tmp, os_temp_path);
+                tmp[strlen(tmp) - 1] = '\0';
+                if (stat(tmp, &st)) MKDIR(tmp);
+        }
 #elif defined(USE_X11) || defined(USE_GCU)
 	if ((c = getenv("TMPDIR"))) strcpy(os_temp_path, c);
 	else if ((c = getenv("TMP"))) strcpy(os_temp_path, c);


### PR DESCRIPTION
## Summary
- Redirect SDL2 client file I/O to the SDL2 user directory
- Store temporary files and logs in the SDL2 temp folder
- Ensure SDL2 builds create and use the SDL2 temp directory

## Testing
- `make -f makefile.sdl2 all`


------
https://chatgpt.com/codex/tasks/task_e_68af38ed55408332a9611753371f9759