### PR TITLE
Copy scripts to user script directory on first run

### DIFF
--- a/src/client/c-files.c
+++ b/src/client/c-files.c
@@ -792,6 +792,26 @@ void init_file_paths(char *path) {
 			if (!check_dir2(*targets[i])) {
 				plog_fmt("Creating directory in user data location: %s", *targets[i]);
 				MKDIR(*targets[i]);
+
+				/* After creating the script directory, copy default scripts. */
+				if (i == 0) {
+					DIR *dp;
+					struct dirent *ep;
+					char src[1024], dst[1024];
+
+					dp = opendir(ANGBAND_DIR_SCPT);
+					if (dp) {
+						while ((ep = readdir(dp)) != NULL) {
+							if (ep->d_name[0] == '.') continue;
+							path_build(src, sizeof(src), ANGBAND_DIR_SCPT, ep->d_name);
+							path_build(dst, sizeof(dst), ANGBAND_USER_DIR_SCPT, ep->d_name);
+							if (my_fexists(src)) {
+								my_fcopy(src, dst);
+							}
+						}
+					closedir(dp);
+					}
+				}
 			}
 		}
 		fprintf(stderr, "jezek - init_file_paths: ANGBAND_USER_DIR: %s\n", ANGBAND_USER_DIR);


### PR DESCRIPTION
## Summary
- Copy default scripts into `ANGBAND_USER_DIR_SCPT` when it's created

## Testing
- `make -f makefile.sdl2 all` *(fails: build interrupted during Windows cross compile)*

------
https://chatgpt.com/codex/tasks/task_e_68b46e04ca4c8332beb37d9fe5f07119